### PR TITLE
Don't count characters above the SMP as surrogates

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -4,7 +4,7 @@ export const strPosToUni = (s: string, strOffset: number = s.length) => {
   let i = 0
   for (; i < strOffset; i++) {
     const code = s.charCodeAt(i)
-    if (code >= 0xd800) {
+    if (code >= 0xd800 && code <= 0xdfff) {
       pairs++
       i++ // Skip the second part of the pair.
     }
@@ -17,7 +17,7 @@ export const uniToStrPos = (s: string, uniOffset: number) => {
   let pos = 0
   for (; uniOffset > 0; uniOffset--) {
     const code = s.charCodeAt(pos)
-    pos += code >= 0xd800 ? 2 : 1
+    pos += code >= 0xd800 && code <= 0xdfff ? 2 : 1
   }
   return pos
 }


### PR DESCRIPTION
The supplementary plane lies between 0xd800 and 0xdfff, anything outside that range should not be counted as a pair.